### PR TITLE
Updating the leaking-user test to reproduce a problem I'd found earlier.

### DIFF
--- a/t/lib/TestApp/Controller/Root.pm
+++ b/t/lib/TestApp/Controller/Root.pm
@@ -37,7 +37,7 @@ sub authenticate :Path('/authenticate') {
 
 sub leaking_users :Path('/leaking_users') {
     my ( $self, $c ) = @_;
-    $c->res->body($c->get_auth_realm('twitter')->credential->twitter_user);
+    $c->res->body($c->get_auth_realm('twitter')->credential->twitter_user->{id});
 }
 
 1;


### PR DESCRIPTION
Per Yanick's request, constructing a simulation of an issue I ran into when using the current release of this module in a live Catalyst-based application. 

Changes made include using two different `$mech` objects (to simulate two separate but simultaneous sessions), and having the /leaking_users action display the Twitter ID of the currently authenticated user.

Please disregard the first two no-op change-chunks in basic-app.t; not sure how those got in there.
