### PR TITLE
ssl option must now be passed

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Catalyst-Authentication-Credential-Twitter
 
+ - pass ssl => 1 option to Net::Twitter, to silence deprecation warnings
+   (GH#4, Karen Etheridge)
+
 2.0.1 2013-06-17
  [BUG FIXES]
  - Requiring the API::RESTv1_1 trait on every Net::Twitter object created.

--- a/lib/Catalyst/Authentication/Credential/Twitter.pm
+++ b/lib/Catalyst/Authentication/Credential/Twitter.pm
@@ -56,6 +56,7 @@ sub new {
 		'traits'        	=> ['API::RESTv1_1', 'OAuth'],
 		'consumer_key' 		=> $self->consumer_key, 
         'consumer_secret'	=> $self->consumer_secret,
+		'ssl'				=> 1,
 	}));
 
     return $self;
@@ -79,6 +80,7 @@ sub authenticate_twitter {
 		'traits'        	=> ['API::RESTv1_1', 'OAuth'],
 		'consumer_key' 		=> $self->consumer_key,
         'consumer_secret'	=> $self->consumer_secret,
+		'ssl'				=> 1,
 	}));
 
 	if (!$access_token && !$access_token_secret) {
@@ -153,6 +155,7 @@ sub authenticate_twitter_url {
 		'traits'        	=> ['API::RESTv1_1', 'OAuth'],
 		'consumer_key' 		=> $self->consumer_key,
         'consumer_secret'	=> $self->consumer_secret,
+		'ssl'				=> 1,
 	));
 
     my $uri = $self->_twitter->get_authentication_url( 'callback'	=> $c->config->{'twitter_callback_url'} || $self->callback_url );


### PR DESCRIPTION
...otherwise, this warning is spewed from Net::Twitter:

The Twitter API now requires SSL. Add ( ssl => 1 ) to the options passed to new
to enable it.  For backwards compatibility, SSL is disabled by default in this
version. Passing the ssl option to new will disable this warning. If you are
using a Twitter API compatbile service that does not support SSL, add
( ssl => 0 ) to disable this warning and preserve non-SSL connections in future
